### PR TITLE
Add Dockerfile

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,0 +1,15 @@
+FROM cupy/cupy
+
+# Install basic packages
+RUN apt-get update -y && apt-get upgrade -y && \
+        apt-get install -y wget git libpython3-dev build-essential && \
+        apt-get autoremove -y && apt-get clean -y && apt-get autoclean -y
+
+# Install python3 modules
+RUN pip3 install --upgrade --no-cache-dir numpy matplotlib Pillow
+
+# Install pytorch
+RUN pip3 install torch torchvision
+
+RUN cd /opt && git clone https://github.com/sniklaus/pytorch-liteflownet
+WORKDIR /opt/pytorch-liteflownet


### PR DESCRIPTION
A Dockerfile can be very useful as the dependencies are not that easy to install. It took me a few hours to figure out how to get it to work, so hopefully this could save others some time, even though the Dockerfile is quite simple in the end.

It can be build and run by using for example:
```
docker build -t liteflownet/pytorch:latest docker
docker run --gpus all -it liteflownet/pytorch:latest /bin/bash
```
